### PR TITLE
Include asdf as our universal version manager

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -8,9 +8,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG USER=abc
 ARG PUID=1000
 ARG PGID=1000
-ARG VIM_DEPS="ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip doxygen"
 
 ENV TZ="Europe/Amsterdam"
+ENV NEOVIM_VERSION="nightly"
+ENV NODE_VERSION="lts"
+
+SHELL ["/bin/bash", "-c"]
 
 RUN \
   ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ >> /etc/timezone \
@@ -34,33 +37,14 @@ RUN \
   && echo "abc ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$USER \
   && chmod 0440 /etc/sudoers.d/$USER \
   && mkdir -p /app /config/.local/bin /defaults \
-  && echo "*** Build Neovim from source ***" \
-  && cd /config \
-  && git clone https://github.com/neovim/neovim \
-  && cd neovim \
-  && make CMAKE_BUILD_TYPE=Release \
-  && make CMAKE_INSTALL_PREFIX=/config/.local/bin/nvim install \
-  && ln -s /config/.local/bin/nvim /config/.local/bin/vim \
-  && rm -rf /config/neovim \
+  && echo "*** Set up Asdf ***" \
+  && git clone https://github.com/asdf-vm/asdf.git /config/.asdf \
+  && source /config/.asdf/asdf.sh \
+  && asdf plugin add neovim https://github.com/richin13/asdf-neovim.git \
+  && asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git \
+  && asdf install nodejs $NODE_VERSION \
+  && asdf install neovim $NEOVIM_VERSION \
   && echo "*** Cleaning up build dependencies ***" \
-  && apt-get -y remove $VIM_DEPS \
   && apt-get -y autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# TODO reconsider how to setup and configure the development environment
-# RUN --mount=type=ssh \
-#   echo "*** Setting up development environment ***" \
-#   # Oh My Zsh
-#   && sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" \
-#   && rm $HOME/.zshrc \
-#   # SSH
-#   && mkdir $HOME/.ssh \
-#   && ssh-keyscan github.com >> $HOME/.ssh/known_hosts \
-#   # Dotfiles
-#   && git clone git@github.com:99linesofcode/dotfiles.git $HOME/.config/dotfiles \
-#   && ln -s $HOME/.config/dotfiles/.zshrc .zshrc \
-#   && ln -s $HOME/.config/dotfiles/.gitconfig .gitconfig \
-#   && ln -s $HOME/.config/dotfiles/.gitignore .gitignore \
-#   && ln -s $HOME/.config/dotfiles/.gitignore_global .gitignore_global \
-#   && ln -s $HOME/.config/dotfiles/.config .config

--- a/php/devcontainer/Dockerfile
+++ b/php/devcontainer/Dockerfile
@@ -5,10 +5,14 @@ FROM ghcr.io/99linesofcode/devcontainer:latest
 LABEL maintainer="Jordy Schreuders <jordy@schreuders.it>"
 
 ARG DEBIAN_FRONTEND=noninteractive
+# ARG BUILD_DEPS="autoconf bison gettext libgd-dev libcurl4-openssl-dev libedit-dev libicu-dev libjpeg-dev libmysqlclient-dev libonig-dev libpng-dev libpq-dev libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libzip-dev openssl pkg-config re2c zlib1g-dev"
 
 ENV PHP_VERSION="8.1"
 
+SHELL ["/bin/bash", "-c"]
+
 RUN \
+  # TODO swap to asdf install once issues with the plugin have been resolved
   echo "*** Set up PHP and Composer ***" \
   && mkdir -p $HOME/.gnupg \
   && chmod 600 $HOME/.gnupg \
@@ -20,6 +24,18 @@ RUN \
   && apt-get update && apt-get install -y --no-install-recommends \
   php$PHP_VERSION-cli \
   && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer
+
+# && echo "*** Install PHP through ASDF ***" \
+# && apt-get update && apt-get install -y --no-install-recommends \
+# $BUILD_DEPS \
+# && source /config/.asdf/asdf.sh \
+# && asdf plugin-add php https://github.com/asdf-community/asdf-php.git \
+# && asdf install php PHP_VERSION \
+# && echo "*** Cleaning up build dependencies ***" \
+# && apt-get -y remove $BUILD_DEPS \
+# && apt-get -y autoremove \
+# && apt-get clean \
+# && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 USER $USER
 


### PR DESCRIPTION
I've included `nodejs` and replaced the manual build of `neovim` in favor of the asdf plugin. The PHP build fails when running OpenSSL 3.0 so I'm sticking with the install from PPA for now.