### PR TITLE
Fix refactor oversights

### DIFF
--- a/bttr/Dockerfile
+++ b/bttr/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.authors="99linesofcode@gmail.com"
 ARG PHP_VERSION
 
 RUN \
-  export PACKAGE_VERSION="$(echo ${PHP_VERSION} | sed -E 's/(\.0?)+//g'" \
+  export PHP_VERSION="$(echo ${PHP_VERSION} | sed -E 's/(\.0?)+//g')" \
   && echo "*** Installing BTTR dependencies ***" \
   && apk add --no-cache --upgrade \
   mariadb-client \

--- a/bttr/devcontainer/Dockerfile
+++ b/bttr/devcontainer/Dockerfile
@@ -14,9 +14,9 @@ ARG PHP_VERSION
 ARG TZ="Europe/Amsterdam"
 ARG USER=abc
 
-SHELL ["zsh", "-c"]
-
 USER root
+
+SHELL ["/bin/zsh", "-c"]
 
 RUN \
   echo "*** Set timezone ***" \

--- a/bttr/devcontainer/Dockerfile
+++ b/bttr/devcontainer/Dockerfile
@@ -20,7 +20,7 @@ USER root
 
 RUN \
   echo "*** Set timezone ***" \
-  && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+  && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} >> /etc/timezone \
   && echo "*** Installing BTTR dependencies ***" \
   && apt-get update && apt-get install -y --no-install-recommends \
   libjpeg-turbo8-dev \

--- a/bttr/devcontainer/Dockerfile
+++ b/bttr/devcontainer/Dockerfile
@@ -35,24 +35,4 @@ RUN \
   php${PHP_VERSION}-redis \
   php${PHP_VERSION}-xsl
 
-# php${PHP_VERSION}-bcmath \
-# php${PHP_VERSION}-curl \
-# php${PHP_VERSION}-dev \
-# php${PHP_VERSION}-imap \
-# php${PHP_VERSION}-igbinary \
-# php${PHP_VERSION}-intl \
-# php${PHP_VERSION}-ldap \
-# php${PHP_VERSION}-mbstring \
-# php${PHP_VERSION}-memcached \
-# php${PHP_VERSION}-msgpack \
-# php${PHP_VERSION}-pcov \
-# php${PHP_VERSION}-pgsql \
-# php${PHP_VERSION}-readline \
-# php${PHP_VERSION}-soap \
-# php${PHP_VERSION}-sqlite3 \
-# php${PHP_VERSION}-swoole \
-# php${PHP_VERSION}-xml \
-# php${PHP_VERSION}-xdebug \
-# php${PHP_VERSION}-zip
-
 USER $USER

--- a/bttr/docker-compose.yml
+++ b/bttr/docker-compose.yml
@@ -1,54 +1,138 @@
 services:
   devcontainer:
-    extends:
-      file: ../php/docker-compose.yml
-      service: devcontainer
+    container_name: ${APP_NAME}.devcontainer
     build:
+      context: ./devcontainer
+      # See https://docs.docker.com/compose/compose-file/build/#ssh
+      ssh:
+        - default
       args:
         - PHP_VERSION=8.0
+        - TZ=${TIMEZONE-Europe/Amsterdam}
+    working_dir: /config/www
+    tty: true
     volumes:
+      - $HOME/.ssh:/config/.ssh
+      - $HOME/.npmrc:/config/.npmrc
+      - $HOME/.config/composer/auth.json:/config/.config/composer/auth.json
       - $HOME/Development/bttr/${APP_NAME}:/config/www
 
   php:
-    extends:
-      file: ../php/docker-compose.yml
-      service: php
+    container_name: ${APP_NAME}.php
     build:
+      context: .
       args:
         - PHP_VERSION=8.0
+        - TZ=${TIMEZONE-Europe/Amsterdam}
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    ports:
+      - '${FORWARD_PHP_HTTP_PORT:-80}:80'
+      - '${FORWARD_PHP_HTTPS_PORT:-443}:443'
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - XDEBUG_MODE=${PHP_XDEBUG_MODE:-off}
+      - XDEBUG_CONFIG=${PHP_XDEBUG_CONFIG:-client_host=host.docker.internal}
     volumes:
       - $HOME/Development/bttr/${APP_NAME}/api:/config/www
-    depends_on:
-      - meilisearch
-      - mysql
-      - redis
 
   mysql:
-    extends:
-      file: ../php/docker-compose.yml
-      service: mysql
+    container_name: ${APP_NAME}.mysql
+    image: mysql/mysql-server:8.0
+    ports:
+      - ${FORWARD_DB_PORT:-3306}:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_ROOT_HOST=%
+      - MYSQL_DATABASE=${DB_DATABASE}
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - vol.mysql:/var/lib/mysql
+      # - $HOME/dbdump.sql:/docker-entrypoint-initdb.d/dbdump.sql
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}" ]
+      retries: 3
+      timeout: 5s
 
   redis:
-    extends:
-      file: ../php/docker-compose.yml
-      service: redis
+    container_name: ${APP_NAME}.redis
+    image: redis:alpine
+    ports:
+      - ${FORWARD_REDIS_PORT:-6379}:6379
+    volumes:
+      - vol.redis:/data
+    healthcheck:
+      test: [ CMD, redis-cli, ping ]
+      retries: 3
+      timeout: 5s
 
   meilisearch:
-    extends:
-      file: ../php/docker-compose.yml
-      service: meilisearch
+    container_name: ${APP_NAME}.meilisearch
+    image: getmeili/meilisearch:v0.28.1
+    ports:
+      - ${FORWARD_MEILISEARCH_PORT:-7700}:7700
+    volumes:
+      - vol.meilisearch:/meili_data
+    healthcheck:
+      test:
+        [
+          CMD,
+          wget,
+          --no-verbose,
+          --spider,
+          http://localhost:7700/health
+        ]
+      retries: 3
+      timeout: 5s
+
+  # FIXME serve different urls for process.browser and SSR before we can migrate to a containerized node version
+  # node:
+  #   container_name: ${APP_NAME}.node
+  #   image: node:14.21.1
+  #   user: node
+  #   working_dir: /var/www/html
+  #   extra_hosts:
+  #     - host.docker.internal:host-gateway
+  #   ports:
+  #     - ${FORWARD_NODE_PORT:-3000}:3000
+  #     - ${FORWARD_VITE_PORT:-24678}:24678
+  #   environment:
+  #     - NODE_ENV=${APP_ENV:-development}
+  #     - NUXT_HOST=node
+  #     - NUXT_PORT=${FORWARD_NODE_PORT:-3000}
+  #   volumes:
+  #     - /home/jordy/Development/bttr/${APP_NAME}/nuxt:/var/www/html
+  #   command: npm run dev
+  #   depends_on:
+  #     - php
 
   phpmyadmin:
-    extends:
-      file: ../php/docker-compose.yml
-      service: phpmyadmin
-    depends_on:
-      - mysql
+    image: phpmyadmin:latest
+    container_name: ${APP_NAME}.phpmyadmin
+    environment:
+      - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+      - PMA_HOST=${APP_NAME}.mysql
+      - PMA_PMADB=phpmyadmin
+      - UPLOAD_LIMIT=512M
+    restart: unless-stopped
+    ports:
+      - ${PHPMYADMIN_PORT:-8888}:80
 
   mailpit:
-    extends:
-      file: ../php/docker-compose.yml
-      service: mailpit
+    container_name: ${APP_NAME}.mailpit
+    image: axllent/mailpit:latest
+    ports:
+      - ${FORWARD_MAILHOG_PORT:-1025}:1025
+      - ${FORWARD_MAILHOG_DASHBOARD_PORT:-8025}:8025
+
+networks:
+  default:
+    name: ${APP_NAME}.net
+    driver: bridge
 
 volumes:
   vol.mysql:

--- a/bttr/docker-compose.yml
+++ b/bttr/docker-compose.yml
@@ -49,3 +49,14 @@ services:
     extends:
       file: ../php/docker-compose.yml
       service: mailpit
+
+volumes:
+  vol.mysql:
+    name: ${APP_NAME}.vol.mysql
+    driver: local
+  vol.redis:
+    name: ${APP_NAME}.vol.redis
+    driver: local
+  vol.meilisearch:
+    name: ${APP_NAME}.vol.meilisearch
+    driver: local

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -15,8 +15,9 @@ ARG TZ="Europe/Amsterdam"
 ARG USER=abc
 
 RUN \
-  echo "*** Set timezone ***" \
+  echo "*** Set locale and timezone ***" \
   && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+  && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} >> /etc/timezone \
   && echo "*** Install base dependencies ***" \
   && apt-get update && apt-get install -y --no-install-recommends \
   locales \
@@ -34,7 +35,6 @@ RUN \
   fzf \
   ripgrep \
   zsh \
-  && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} >> /etc/timezone \
   && echo "*** Creating abc user ***" \
   && useradd -u ${PUID} -U -d /config -s $(which zsh) -G users ${USER} \
   && echo "abc ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/${USER} \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.authors="99linesofcode@gmail.com"
 ARG PHP_VERSION
 
 RUN \
-  export PHP_VERSION="$(echo ${PHP_VERSION} | sed -E 's/(\.0?)+//g'" \
+  export PHP_VERSION="$(echo ${PHP_VERSION} | sed -E 's/(\.0?)+//g')" \
   && echo "*** Installing runtime packages ***" \
   && apk add --no-cache --upgrade \
   php${PHP_VERSION}-pecl-xdebug

--- a/php/devcontainer/Dockerfile
+++ b/php/devcontainer/Dockerfile
@@ -20,7 +20,7 @@ USER root
 
 RUN \
   echo "*** Set timezone ***" \
-  && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen \
+  && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} >> /etc/timezone \
   && echo "*** Installing PHP ***" \
   && mkdir -p $HOME/.gnupg \
   && chmod 600 $HOME/.gnupg \

--- a/php/devcontainer/Dockerfile
+++ b/php/devcontainer/Dockerfile
@@ -14,9 +14,9 @@ ARG PHP_VERSION
 ARG TZ="Europe/Amsterdam"
 ARG USER=abc
 
-SHELL ["zsh", "-c"]
-
 USER root
+
+SHELL ["/bin/sh", "-c"]
 
 RUN \
   echo "*** Set timezone ***" \
@@ -30,9 +30,15 @@ RUN \
   && gpg --export 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c >> /usr/share/keyrings/ppa_ondrej_php.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" >> /etc/apt/sources.list.d/ppa_ondrej_php.list \
   && apt-get update && apt-get install -y --no-install-recommends \
-  php${PHP_VERSION}-cli
+  php${PHP_VERSION}-cli \
+  && echo "*** Cleaning up build dependencies ***" \
+  && apt-get -y autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 USER $USER
+
+SHELL ["/bin/zsh", "-c"]
 
 RUN \
   echo "*** Installing Composer to $HOME/.local/bin ***" \

--- a/php/devcontainer/Dockerfile
+++ b/php/devcontainer/Dockerfile
@@ -29,8 +29,32 @@ RUN \
   && gpg --recv-key 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c \
   && gpg --export 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c >> /usr/share/keyrings/ppa_ondrej_php.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" >> /etc/apt/sources.list.d/ppa_ondrej_php.list \
+  # TODO we can probably cut down on the dependencies here. I ran into issues with composer install however so including everything Laravel for now
   && apt-get update && apt-get install -y --no-install-recommends \
+  php${PHP_VERSION}-bcmath \
   php${PHP_VERSION}-cli \
+  php${PHP_VERSION}-dev \
+  php${PHP_VERSION}-curl \
+  php${PHP_VERSION}-gd \
+  php${PHP_VERSION}-igbinary \
+  php${PHP_VERSION}-imagick \
+  php${PHP_VERSION}-imap \
+  php${PHP_VERSION}-intl \
+  php${PHP_VERSION}-ldap \
+  php${PHP_VERSION}-mbstring \
+  php${PHP_VERSION}-memcached \
+  php${PHP_VERSION}-msgpack \
+  php${PHP_VERSION}-mysql \
+  php${PHP_VERSION}-pcov \
+  php${PHP_VERSION}-pgsql \
+  php${PHP_VERSION}-readline \
+  php${PHP_VERSION}-redis \
+  php${PHP_VERSION}-soap \
+  php${PHP_VERSION}-sqlite3 \
+  php${PHP_VERSION}-swoole \
+  php${PHP_VERSION}-xml \
+  php${PHP_VERSION}-xdebug \
+  php${PHP_VERSION}-zip \
   && echo "*** Cleaning up build dependencies ***" \
   && apt-get -y autoremove \
   && apt-get clean \

--- a/php/php/Dockerfile
+++ b/php/php/Dockerfile
@@ -16,7 +16,7 @@ ARG PHP_VERSION
 ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
 
 RUN \
-  export PHP_VERSION="$(echo ${PHP_VERSION} | sed -E 's/(\.0?)+//g'" \
+  export PHP_VERSION="$(echo ${PHP_VERSION} | sed -E 's/(\.0?)+//g')" \
   && echo "*** Installing runtime packages ***" \
   && apk add --no-cache --upgrade \
   php${PHP_VERSION}-ctype \

--- a/ruby/devcontainer/Dockerfile
+++ b/ruby/devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_DEPS="autoconf bison patch build-essential rustc libssl-dev libyaml-de
 
 ENV RUBY_VERSION="3.2.1"
 
-SHELL ["zsh", "-c"]
+SHELL ["/bin/sh", "-c"]
 
 USER root
 
@@ -25,6 +25,8 @@ RUN \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 USER $USER
+
+SHELL ["zsh", "-c"]
 
 RUN \
   echo "*** Installing Ruby and Rails ***" \


### PR DESCRIPTION
So, turns out some of the 'optimizations' I did didn't really work. I'd like to be able to use `extends` but the way I was approaching it prior to the revert prevented my containers from being able to each other EVEN THOUGH they were sharing the same network. Needs more time, which currently I'd rather dedicate to improving the ruby containers.