### PR TITLE
style(devcontainer): do not clone personal dotfiles

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -64,7 +64,4 @@ RUN \
   && echo "*** Installing neovim ***" \
   && asdf install neovim $NEOVIM_VERSION \
   && asdf global neovim $NEOVIM_VERSION \
-  && ln -sf /config/.asdf/shims/nvim /config/.local/bin/vim \
-  && echo "*** Installing dotfiles ***" \
-  && git clone https://github.com/99linesofcode/dotfiles.git $HOME/dotfiles \
-  && $HOME/dotfiles/install.sh
+  && ln -sf /config/.asdf/shims/nvim /config/.local/bin/vim


### PR DESCRIPTION
This PR does away with the cloning and installation of my personal dotfiles repository in favor of [personalizing with dotfiles repositories settings for VSCode](https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories). Now, the `devcontainer` properly generalized and can be safely used as a base image without having to many any modifications.