### PR TITLE
fix: install missing pager

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -30,6 +30,7 @@ RUN \
   gnupg \
   ssh \
   curl \
+  less \
   zip \
   unzip \
   git \


### PR DESCRIPTION
Without a pager, certain terminal commands would automatically scroll down to the bottom of the output.