### PR TITLE
List all dependencies in devcontainer extensions

### DIFF
--- a/bttr/.devcontainer.json
+++ b/bttr/.devcontainer.json
@@ -61,20 +61,35 @@
         }
       },
       "extensions": [
+        // Global dependencies
+        "eamodio.gitlens",
+        "enkia.tokyo-night",
+        "GitHub.copilot",
+        "ms-vscode-remote.vscode-remote-extensionpack",
+        "vscodevim.vim",
+        // Formatters en Linters
+        "bierner.markdown-mermaid",
+        "DavidAnson.vscode-markdownlint",
+        "dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig",
+        "gruntfuggly.todo-tree",
+        "jock.svg",
+        "naumovs.color-highlight",
+        "ms-azuretools.vscode-docker",
+        "stylelint.vscode-stylelint",
+        "mikestead.dotenv",
+        "vscode.docker",
+        "vscode.yaml",
+        "yo1dog.cursor-align",
+        "yzhang.markdown-all-in-one",
+        // PHP development
         "bmewburn.vscode-intelephense-client",
         "bradlc.vscode-tailwindcss",
         "calebporzio.better-phpunit",
-        "dbaeumer.vscode-eslint",
-        "editorconfig.editorconfig",
-        "eamodio.gitlens",
         "graphql.vscode-graphql",
-        "gruntfuggly.todo-tree",
         "junstyle.php-cs-fixer",
-        "mikestead.dotenv",
-        "ms-azuretools.vscode-docker",
-        "naumovs.color-highlight",
         "neilbrayfield.php-docblocker",
-        "stylelint.vscode-stylelint",
+        "open-southeners.laravel-pint",
         "vue.volar",
         "xdebug.php-debug"
       ]

--- a/php/.devcontainer.json
+++ b/php/.devcontainer.json
@@ -60,20 +60,33 @@
         }
       },
       "extensions": [
-        "bmewburn.vscode-intelephense-client",
-        "bradlc.vscode-tailwindcss",
+        // Global dependencies
+        "eamodio.gitlens",
+        "enkia.tokyo-night",
+        "GitHub.copilot",
+        "ms-vscode-remote.vscode-remote-extensionpack",
+        "vscodevim.vim",
+        // Formatters en Linters
+        "bierner.markdown-mermaid",
+        "DavidAnson.vscode-markdownlint",
         "dbaeumer.vscode-eslint",
         "editorconfig.editorconfig",
-        "eamodio.gitlens",
         "gruntfuggly.todo-tree",
-        "m1guelpf.better-pest",
-        "mikestead.dotenv",
-        "ms-azuretools.vscode-docker",
+        "jock.svg",
         "naumovs.color-highlight",
+        "ms-azuretools.vscode-docker",
+        "stylelint.vscode-stylelint",
+        "mikestead.dotenv",
+        "vscode.docker",
+        "vscode.yaml",
+        "yo1dog.cursor-align",
+        "yzhang.markdown-all-in-one",
+        // PHP development
+        "bmewburn.vscode-intelephense-client",
+        "bradlc.vscode-tailwindcss",
+        "m1guelpf.better-pest",
         "neilbrayfield.php-docblocker",
         "open-southeners.laravel-pint",
-        "stylelint.vscode-stylelint",
-        "tejanium.stimulusjs",
         "xdebug.php-debug"
       ]
     }

--- a/ruby/.devcontainer.json
+++ b/ruby/.devcontainer.json
@@ -18,6 +18,22 @@
           "javascript",
           "typescript"
         ],
+        "rubyLsp.enabledFeatures": {
+          "codeActions": false,
+          "diagnostics": false,
+          "documentHighlights": true,
+          "documentLink": false,
+          "documentSymbols": false,
+          "foldingRanges": false,
+          "formatting": false,
+          "hover": false,
+          "inlayHint": true,
+          "onTypeFormatting": false,
+          "selectionRanges": false,
+          "semanticHighlighting": true,
+          "completion": false,
+          "codeLens": true
+        },
         "search.exclude": {
           "**/.git/**": true,
           "**/bundle/**": true
@@ -29,21 +45,35 @@
         "terminal.integrated.defaultProfile.linux": "zsh"
       },
       "extensions": [
-        "bradlc.vscode-tailwindcss",
-        "castwide.solargraph",
-        "dbaeumer.vscode-eslint",
+        // Global dependencies
         "eamodio.gitlens",
+        "enkia.tokyo-night",
+        "GitHub.copilot",
+        "ms-vscode-remote.vscode-remote-extensionpack",
+        "vscodevim.vim",
+        // Formatters en Linters
+        "bierner.markdown-mermaid",
+        "DavidAnson.vscode-markdownlint",
+        "dbaeumer.vscode-eslint",
         "editorconfig.editorconfig",
         "gruntfuggly.todo-tree",
+        "jock.svg",
+        "naumovs.color-highlight",
+        "ms-azuretools.vscode-docker",
+        "stylelint.vscode-stylelint",
+        "mikestead.dotenv",
+        "vscode.docker",
+        "vscode.yaml",
+        "yo1dog.cursor-align",
+        "yzhang.markdown-all-in-one",
+        // Ruby development
+        "bradlc.vscode-tailwindcss",
+        "castwide.solargraph",
         "hridoy.rails-snippets",
         "kaiwood.endwise",
         "KoichiSasada.vscode-rdbg",
         "MateuszDrewniak.ruby-test-runner",
-        "mikestead.dotenv",
-        "ms-azuretools.vscode-docker",
-        "naumovs.color-highlight",
         "Shopify.ruby-lsp",
-        "stylelint.vscode-stylelint",
         "tejanium.stimulusjs",
         "vortizhe.simple-ruby-erb"
       ]


### PR DESCRIPTION
This should reduce the amount of extensions installed on the host machine. Ideally, some of these are installed globally of inside WSL since they will be used in practically any programming environment and simply expand vscode with IDE functionality (gitlens and linters come to mind here) but for anyone using these as a starter for a codespace or their own development environments it's good to be explicit.

I'm hoping that vscode installs the extensions in their preferred location but as of now, I haven't verified that yet.