### PR TITLE
refactor(ruby): no need for ruby-lsp for now

### DIFF
--- a/ruby/.devcontainer.json
+++ b/ruby/.devcontainer.json
@@ -18,22 +18,6 @@
           "javascript",
           "typescript"
         ],
-        "rubyLsp.enabledFeatures": {
-          "codeActions": false,
-          "diagnostics": false,
-          "documentHighlights": true,
-          "documentLink": false,
-          "documentSymbols": false,
-          "foldingRanges": false,
-          "formatting": false,
-          "hover": false,
-          "inlayHint": true,
-          "onTypeFormatting": false,
-          "selectionRanges": false,
-          "semanticHighlighting": true,
-          "completion": false,
-          "codeLens": true
-        },
         "search.exclude": {
           "**/.git/**": true,
           "**/bundle/**": true
@@ -73,7 +57,6 @@
         "kaiwood.endwise",
         "KoichiSasada.vscode-rdbg",
         "MateuszDrewniak.ruby-test-runner",
-        "Shopify.ruby-lsp",
         "tejanium.stimulusjs",
         "vortizhe.simple-ruby-erb"
       ]


### PR DESCRIPTION
Once the ruby-lsp gains support for basic go to definition, we might be able to do away with Solargraph all together. At this point, I'm not sure of the need for a static type checker and which one to adopt.