### PR TITLE
Make dotfiles directory configurable

### DIFF
--- a/bttr/.devcontainer.json
+++ b/bttr/.devcontainer.json
@@ -14,6 +14,9 @@
         "[php]": {
           "editor.defaultFormatter": "junstyle.php-cs-fixer"
         },
+        "dotfiles.repository": "99linesofcode/dotfiles",
+        "dotfiles.targetPath": "/config/dotfiles",
+        "dotfiles.installCommand": "/config/dotfiles/install.sh",
         "emmet.includeLanguages": {
           "blade": "html",
           "vue": "html",
@@ -47,6 +50,8 @@
           "scss",
           "vue"
         ],
+        // TODO update when proper support for glob patterns is released
+        // See: https://github.com/microsoft/vscode/issues/134415 and related
         "search.exclude": {
           "**/.git/**": true,
           "**/.nuxt/**": true,

--- a/php/.devcontainer.json
+++ b/php/.devcontainer.json
@@ -89,6 +89,7 @@
         "onecentlin.laravel-blade",
         "open-southeners.laravel-pint",
         "SanderRonde.phpstan-vscode",
+        "shufo.vscode-blade-formatter",
         "xdebug.php-debug"
       ]
     }

--- a/php/.devcontainer.json
+++ b/php/.devcontainer.json
@@ -14,6 +14,9 @@
         "[php]": {
           "editor.defaultFormatter": "open-southeners.laravel-pint"
         },
+        "dotfiles.repository": "99linesofcode/dotfiles",
+        "dotfiles.targetPath": "/config/dotfiles",
+        "dotfiles.installCommand": "/config/dotfiles/install.sh",
         "emmet.includeLanguages": {
           "blade": "html",
           "vue": "html",
@@ -46,6 +49,8 @@
           "scss",
           "vue"
         ],
+        // TODO update when proper support for glob patterns is released
+        // See: https://github.com/microsoft/vscode/issues/134415 and related
         "search.exclude": {
           "**/.git/**": true,
           "**/.nuxt/**": true,

--- a/ruby/.devcontainer.json
+++ b/ruby/.devcontainer.json
@@ -14,6 +14,9 @@
         "[ruby]": {
           "editor.defaultFormatter": "castwide.solargraph"
         },
+        "dotfiles.repository": "99linesofcode/dotfiles",
+        "dotfiles.targetPath": "/config/dotfiles",
+        "dotfiles.installCommand": "/config/dotfiles/install.sh",
         "eslint.validate": [
           "javascript",
           "typescript"


### PR DESCRIPTION
Prior to this PR and changes to the underlying container, my dotfiles were pulled in at build time. With these changes, users can configure their development containers to pull in their own dotfile configuration from any repository they please. For more information see: https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories

Additionally, you may want to take a look at my dotfiles repository here: https://github.com/99linesofcode/dotfiles and specifically the install script: https://github.com/99linesofcode/dotfiles/blob/main/install.sh.