### PR TITLE
chore(vim): replace vim with neovim plugin

### DIFF
--- a/devcontainer/php/.devcontainer.json
+++ b/devcontainer/php/.devcontainer.json
@@ -70,7 +70,7 @@
         "enkia.tokyo-night",
         "GitHub.copilot",
         "ms-vscode-remote.vscode-remote-extensionpack",
-        "vscodevim.vim",
+        "asvetliakov.vscode-neovim",
         // Formatters en Linters
         "bierner.markdown-mermaid",
         "DavidAnson.vscode-markdownlint",

--- a/devcontainer/ruby/.devcontainer.json
+++ b/devcontainer/ruby/.devcontainer.json
@@ -37,7 +37,7 @@
         "enkia.tokyo-night",
         "GitHub.copilot",
         "ms-vscode-remote.vscode-remote-extensionpack",
-        "vscodevim.vim",
+        "asvetliakov.vscode-neovim",
         // Formatters en Linters
         "bierner.markdown-mermaid",
         "DavidAnson.vscode-markdownlint",


### PR DESCRIPTION
Neovim is a fork of Vim to allow greater extensibility and integration. This extension uses a fully embedded Neovim instance, no more half-complete Vim emulation! VSCode's native functionality is used for insert mode and editor commands, making the best use of both editors.

Additionally, lazyvim has tight integration with vscode through a dedicated vscode plugin. This allows me to manage my configuration for nvim from lazyvim and gives access to some of it's features.