### PR TITLE
Add zoxide and neofetch dependencies

### DIFF
--- a/devcontainer/base/Dockerfile
+++ b/devcontainer/base/Dockerfile
@@ -56,4 +56,8 @@ USER ${USER}
 
 RUN \
   echo "*** Setting up Asdf ***" \
-  && git clone https://github.com/asdf-vm/asdf.git /config/.asdf
+  && git clone https://github.com/asdf-vm/asdf.git /config/.asdf \
+  && echo "*** Installing zoxide ***" \
+  && . /config/.asdf/asdf.sh \
+  && asdf plugin add zoxide https://github.com/nyrst/asdf-zoxide.git \
+  && asdf install zoxide latest

--- a/devcontainer/base/Dockerfile
+++ b/devcontainer/base/Dockerfile
@@ -15,8 +15,6 @@ ARG USER=abc
 
 WORKDIR /app
 
-SHELL ["/bin/sh", "-c"]
-
 RUN \
   echo "*** Installing core dependencies ***" \
   && apt-get update && apt-get install -y --no-install-recommends \

--- a/devcontainer/php/Dockerfile
+++ b/devcontainer/php/Dockerfile
@@ -18,8 +18,6 @@ WORKDIR /app
 
 USER root
 
-SHELL ["/bin/sh", "-c"]
-
 RUN \
   echo "*** Override timezone information ***" \
   && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} >> /etc/timezone \
@@ -63,13 +61,11 @@ RUN \
 
 USER $USER
 
-SHELL ["/bin/zsh", "-c"]
-
 RUN \
   echo "*** Installing Composer to $HOME/.local/bin ***" \
   && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/config/.local/bin --filename=composer \
   && echo "*** Installing Node.js ***" \
-  && source /config/.asdf/asdf.sh \
+  && . /config/.asdf/asdf.sh \
   && asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git \
   && asdf install nodejs ${NODE_VERSION} \
   && asdf global nodejs ${NODE_VERSION}

--- a/devcontainer/ruby/Dockerfile
+++ b/devcontainer/ruby/Dockerfile
@@ -18,8 +18,6 @@ WORKDIR /app
 
 USER root
 
-SHELL ["/bin/sh", "-c"]
-
 RUN \
   echo "*** Override timezone information ***" \
   && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} >> /etc/timezone \
@@ -51,11 +49,9 @@ RUN \
 
 USER ${USER}
 
-SHELL ["/bin/zsh", "-c"]
-
 RUN \
   echo "*** Installing Node.js ***" \
-  && source /config/.asdf/asdf.sh \
+  && . /config/.asdf/asdf.sh \
   && asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git \
   && asdf install nodejs ${NODE_VERSION} \
   && asdf global nodejs ${NODE_VERSION} \


### PR DESCRIPTION
While not entirely necessary, these packages get rid of some warnings due to my dotfiles/ depending on them. Zoxide also makes navigating the terminal environment a breeze.

Additionally, I've refactored the `Dockerfile`s a bit so there is no longer a need to switch `SHELL`s.