### PR TITLE
Update container and volume naming convention

### DIFF
--- a/devcontainer/base/docker-compose.yml
+++ b/devcontainer/base/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   devcontainer:
-    container_name: ${APP_NAME}.devcontainer
+    container_name: ${APP_NAME}-devcontainer
     build:
       context: .
       # See https://docs.docker.com/compose/compose-file/build/#ssh
@@ -24,7 +24,7 @@ services:
   # FIXME dont volume mount /node_modules to drastically improve performance
   #
   # nodejs:
-  #   container_name: ${APP_NAME}.nodejs
+  #   container_name: ${APP_NAME}-nodejs
   #   image: node:alpine
   #   user: node
   #   working_dir: /var/www/html
@@ -44,7 +44,7 @@ services:
   #     - php
 
   mysql:
-    container_name: ${APP_NAME}.mysql
+    container_name: ${APP_NAME}-mysql
     image: mysql/mysql-server:8.0
     ports:
       - ${FORWARD_DB_PORT:-3306}:3306
@@ -60,7 +60,7 @@ services:
       timeout: 5s
 
   redis:
-    container_name: ${APP_NAME}.redis
+    container_name: ${APP_NAME}-redis
     image: redis:alpine
     ports:
       - ${FORWARD_REDIS_PORT:-6379}:6379
@@ -71,12 +71,12 @@ services:
 
   phpmyadmin:
     image: phpmyadmin:latest
-    container_name: ${APP_NAME}.phpmyadmin
+    container_name: ${APP_NAME}-phpmyadmin
     environment:
       - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
       - MYSQL_USER=${DB_USERNAME}
       - MYSQL_PASSWORD=${DB_PASSWORD}
-      - PMA_HOST=${APP_NAME}.mysql
+      - PMA_HOST=${APP_NAME}-mysql
       - PMA_PMADB=phpmyadmin
       - UPLOAD_LIMIT=512M
     restart: unless-stopped
@@ -88,7 +88,7 @@ services:
       timeout: 5s
 
   mailpit:
-    container_name: ${APP_NAME}.mailpit
+    container_name: ${APP_NAME}-mailpit
     image: axllent/mailpit:latest
     ports:
       - ${FORWARD_MAILPIT_PORT:-1025}:1025
@@ -100,5 +100,5 @@ services:
 
 networks:
   default:
-    name: "${APP_NAME}.net"
+    name: "${APP_NAME}-net"
     driver: bridge

--- a/devcontainer/php/docker-compose.yml
+++ b/devcontainer/php/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       file: ../base/docker-compose.yml
       service: mysql
     volumes:
-      - vol.mysql:/var/lib/mysql
+      - mysql:/var/lib/mysql
       # - $HOME/dbdump.sql:/docker-entrypoint-initdb.d/dbdump.sql # dbdump.sql is read on init and can be used to prepopulate the db
 
   phpmyadmin:
@@ -36,10 +36,10 @@ services:
       file: ../base/docker-compose.yml
       service: redis
     volumes:
-      - vol.redis:/data
+      - redis:/data
 
   soketi:
-    container_name: ${APP_NAME}.soketi
+    container_name: ${APP_NAME}-soketi
     image: quay.io/soketi/soketi:latest
     environment:
       - SOKETI_DEBUG=${SOKETI_DEBUG:-1}
@@ -52,12 +52,12 @@ services:
       - ${PUSHER_METRICS_PORT:-9601}:9601
 
   meilisearch:
-    container_name: ${APP_NAME}.meilisearch
+    container_name: ${APP_NAME}-meilisearch
     image: getmeili/meilisearch:latest
     ports:
       - ${FORWARD_MEILISEARCH_PORT:-7700}:7700
     volumes:
-      - vol.meilisearch:/meili_data
+      - meilisearch:/meili_data
     healthcheck:
       test:
         [
@@ -76,7 +76,7 @@ services:
       service: mailpit
 
   # webgrind:
-  #   container_name: ${APP_NAME}.webgrind
+  #   container_name: ${APP_NAME}-webgrind
   #   image: jokkedk/webgrind:latest
   #   ports:
   #     - ${FORWARD_WEBGRIND_PORT:-8080}:80
@@ -84,12 +84,12 @@ services:
   #     - $HOME/Development/profiling/${APP_NAME}:/tmp
 
 volumes:
-  vol.mysql:
-    name: ${APP_NAME}.vol.mysql
+  mysql:
+    name: ${APP_NAME}-vol-mysql
     driver: local
-  vol.redis:
-    name: ${APP_NAME}.vol.redis
+  redis:
+    name: ${APP_NAME}-vol-redis
     driver: local
-  vol.meilisearch:
-    name: ${APP_NAME}.vol.meilisearch
+  meilisearch:
+    name: ${APP_NAME}-vol-meilisearch
     driver: local

--- a/devcontainer/ruby/docker-compose.yml
+++ b/devcontainer/ruby/docker-compose.yml
@@ -1,5 +1,3 @@
-include: ../base/docker-compose.yml
-
 services:
   devcontainer:
     extends:
@@ -34,9 +32,9 @@ services:
       service: mailpit
 
 volumes:
-  vol.mysql:
-    name: ${APP_NAME}.vol.mysql
+  mysql:
+    name: ${APP_NAME}-vol-mysql
     driver: local
-  vol.redis:
-    name: ${APP_NAME}.vol.redis
+  redis:
+    name: ${APP_NAME}-vol-redis
     driver: local


### PR DESCRIPTION
Kamal joins together the `$APP_NAME` and service name with a dash and there is as of yet no way to modify this. Technically we could use different naming conventions for development and production but that will only lead to confusion so I'm aligning things here.

docker-base will no longer be looking in the same place for your container volumes so they will have to be renamed which, unfortunately, is a bit involved. See
https://stackoverflow.com/questions/73233336/rename-docker-volume-on-docker-desktop for more info.