### PR TITLE
docker-base as submodule or subtree

### DIFF
--- a/devcontainer/base/docker-compose.yml
+++ b/devcontainer/base/docker-compose.yml
@@ -1,27 +1,25 @@
 services:
-  devcontainer:
-    container_name: ${APP_NAME}-devcontainer
-    build:
-      context: .
-      # See https://docs.docker.com/compose/compose-file/build/#ssh
-      ssh:
-        - default # lets the builder connect to the default SSH agent
-      args:
-        - PUID=${PUID:-1000}
-        - PGID=${PGID:-1000}
-        - TZ=${TIMEZONE:-Europe/Amsterdam}
-    tty: true
-    extra_hosts:
-      - "host.docker.internal:host-gateway" # for accessing the host from inside the container
-    volumes:
-      - $HOME/.ssh:/config/.ssh:ro # the SSH agent will need access to your configuration
-      - $HOME/.npmrc:/config/.npmrc # necessary when installing packages from a private repository
-      - $HOME/Development/${APP_NAME}:/app
+  # devcontainer:
+  #   container_name: ${APP_NAME}-devcontainer
+  #   build:
+  #     context: .
+  #     # See https://docs.docker.com/compose/compose-file/build/#ssh
+  #     ssh:
+  #       - default # lets the builder connect to the default SSH agent
+  #     args:
+  #       - PUID=${PUID:-1000}
+  #       - PGID=${PGID:-1000}
+  #       - TZ=${TIMEZONE:-Europe/Amsterdam}
+  #   tty: true
+  #   extra_hosts:
+  #     - "host.docker.internal:host-gateway" # for accessing the host from inside the container
+  #   volumes:
+  #     - $HOME/.ssh:/config/.ssh:ro # the SSH agent will need access to your configuration
+  #     - $HOME/.npmrc:/config/.npmrc # necessary when installing packages from a private repository
+  #     - ../:/app
 
-  # Node.js service
-  #
-  # FIXME serve different urls for process.browser and SSR to avoid CORS issues when SSR
-  # FIXME dont volume mount /node_modules to drastically improve performance
+  # FIXME: serve different urls for process.browser and SSR to avoid CORS issues when SSR
+  # FIXME: dont volume mount /node_modules to drastically improve performance
   #
   # nodejs:
   #   container_name: ${APP_NAME}-nodejs

--- a/devcontainer/base/docker-compose.yml
+++ b/devcontainer/base/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   #     - NUXT_HOST=nodejs
   #     - NUXT_PORT=${FORWARD_NODE_PORT:-3000}
   #   volumes:
-  #     - $HOME/Development/${APP_NAME}/nuxt:/var/www/html
+  #     - ../nuxt:/var/www/html
   #   command: npm run dev
   #   depends_on: # NOTE: cannot be used when extending, extract to child
   #     - php

--- a/devcontainer/base/docker-compose.yml
+++ b/devcontainer/base/docker-compose.yml
@@ -52,6 +52,8 @@ services:
       - MYSQL_DATABASE=${DB_DATABASE}
       - MYSQL_USER=${DB_USERNAME}
       - MYSQL_PASSWORD=${DB_PASSWORD}
+    volumes:
+      - mysql:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
       retries: 3
@@ -62,6 +64,8 @@ services:
     image: redis:alpine
     ports:
       - ${FORWARD_REDIS_PORT:-6379}:6379
+    volumes:
+      - redis:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       retries: 3
@@ -95,6 +99,14 @@ services:
       test: ["CMD", "curl", "-Ss", "http://localhost:8025/livez"]
       retries: 3
       timeout: 5s
+
+volumes:
+  mysql:
+    name: ${APP_NAME}-vol-mysql
+    driver: local
+  redis:
+    name: ${APP_NAME}-vol-redis
+    driver: local
 
 networks:
   default:

--- a/devcontainer/php/docker-compose.yml
+++ b/devcontainer/php/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - mysql
       - redis
     volumes:
-      - $HOME/Development/${APP_NAME}:/app
+      - ../:/app
       # - $HOME/Development/profiling/${APP_NAME}:/tmp/xdebug # mount xdebug and cachegrind output for profiling analysis on host machine
 
   mysql:

--- a/devcontainer/php/docker-compose.yml
+++ b/devcontainer/php/docker-compose.yml
@@ -1,10 +1,24 @@
 services:
-  devcontainer:
-    extends:
-      file: ../base/docker-compose.yml
-      service: devcontainer
+  # devcontainer:
+  #   extends:
+  #     file: ../base/docker-compose.yml
+  #     service: devcontainer
+  #   build:
+  #     context: .
+  #   environment:
+  #     - XDEBUG_MODE=${PHP_XDEBUG_MODE:-off}
+  #     - XDEBUG_CONFIG=${PHP_XDEBUG_CONFIG:-client_host=host.docker.internal output_dir=/tmp/xdebug profiler_output_name=cachegrind.out.%R.%u}
+  #   depends_on:
+  #     - meilisearch
+  #     - mysql
+  #     - redis
+  #   volumes:
+  #     - $HOME/.config/composer/auth.json:/config/.config/composer/auth.json # necessary when installing packages from a private repository
+  #     # - $HOME/Development/profiling/${APP_NAME}:/tmp/xdebug # mount xdebug and cachegrind output for profiling analysis on host machine
+
+  php:
     build:
-      context: .
+      context: ./frankenphp/
     environment:
       - XDEBUG_MODE=${PHP_XDEBUG_MODE:-off}
       - XDEBUG_CONFIG=${PHP_XDEBUG_CONFIG:-client_host=host.docker.internal output_dir=/tmp/xdebug profiler_output_name=cachegrind.out.%R.%u}
@@ -13,7 +27,7 @@ services:
       - mysql
       - redis
     volumes:
-      - $HOME/.config/composer/auth.json:/config/.config/composer/auth.json # necessary when installing packages from a private repository
+      - $HOME/Development/${APP_NAME}:/app
       # - $HOME/Development/profiling/${APP_NAME}:/tmp/xdebug # mount xdebug and cachegrind output for profiling analysis on host machine
 
   mysql:

--- a/devcontainer/php/docker-compose.yml
+++ b/devcontainer/php/docker-compose.yml
@@ -34,9 +34,8 @@ services:
     extends:
       file: ../base/docker-compose.yml
       service: mysql
-    volumes:
-      - mysql:/var/lib/mysql
-      # - $HOME/dbdump.sql:/docker-entrypoint-initdb.d/dbdump.sql # dbdump.sql is read on init and can be used to prepopulate the db
+    # volumes:
+    #   - $HOME/dbdump.sql:/docker-entrypoint-initdb.d/dbdump.sql # dbdump.sql is read on init and can be used to prepopulate the db
 
   phpmyadmin:
     extends:
@@ -49,8 +48,6 @@ services:
     extends:
       file: ../base/docker-compose.yml
       service: redis
-    volumes:
-      - redis:/data
 
   soketi:
     container_name: ${APP_NAME}-soketi
@@ -98,12 +95,6 @@ services:
   #     - $HOME/Development/profiling/${APP_NAME}:/tmp
 
 volumes:
-  mysql:
-    name: ${APP_NAME}-vol-mysql
-    driver: local
-  redis:
-    name: ${APP_NAME}-vol-redis
-    driver: local
   meilisearch:
     name: ${APP_NAME}-vol-meilisearch
     driver: local

--- a/devcontainer/php/frankenphp/Caddyfile
+++ b/devcontainer/php/frankenphp/Caddyfile
@@ -1,0 +1,41 @@
+{
+	{$CADDY_GLOBAL_OPTIONS}
+
+	frankenphp {
+		#worker /path/to/your/worker.php
+		{$FRANKENPHP_CONFIG}
+	}
+
+	# https://caddyserver.com/docs/caddyfile/directives#sorting-algorithm
+	order php_server before file_server
+	order php before file_server
+}
+
+{$CADDY_EXTRA_CONFIG}
+
+{$SERVER_NAME:localhost} {
+	root * public/
+	encode zstd gzip
+
+	{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+	# Needed for Symfony, Laravel and other projects using the Symfony HttpFoundation component
+	request_header X-Sendfile-Type x-accel-redirect
+	request_header X-Accel-Mapping ../private-files=/private-files
+
+	intercept {
+		@accel header X-Accel-Redirect *
+		handle_response @accel {
+			root private-files/
+			rewrite * {resp.header.X-Accel-Redirect}
+			method * GET
+
+			# Remove the X-Accel-Redirect header set by PHP for increased security
+			header -X-Accel-Redirect
+
+			file_server
+		}
+	}
+
+	php_server
+}

--- a/devcontainer/php/frankenphp/Dockerfile
+++ b/devcontainer/php/frankenphp/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+
+ARG PACKAGE_VERSION="1.1.0"
+ARG BASE_IMAGE="dunglas/frankenphp:${PACKAGE_VERSION}"
+
+FROM "${BASE_IMAGE}-builder" AS builder
+
+COPY --from=caddy:builder /usr/bin/xcaddy /usr/bin/xcaddy
+
+# CGO must be enabled to build FrankenPHP
+ENV CGO_ENABLED=1 \
+    XCADDY_SETCAP=1 \
+    XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx"
+
+RUN set -eux; \
+  xcaddy build \
+  --output /usr/local/bin/frankenphp \
+  --with github.com/dunglas/frankenphp=./ \
+  --with github.com/dunglas/frankenphp/caddy=./caddy/;
+
+FROM ${BASE_IMAGE} AS runner
+
+WORKDIR /app
+
+RUN set -eux; \
+  install-php-extensions \
+  @composer \
+  intl \
+  pdo_mysql \
+  zip \
+  && pecl install redis \
+  && docker-php-ext-enable redis \
+  && cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini;
+
+# Replace the official binary by the one containing our custom modules
+COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
+COPY --link ./Caddyfile /etc/caddy/Caddyfile
+COPY --link --chmod=755 ./docker-php-entrypoint.sh /usr/local/bin/docker-php-entrypoint
+
+COPY ../ ./
+
+RUN set -eux; \
+  composer install -n --no-cache --prefer-dist --no-dev --no-scripts -o -a
+
+ENTRYPOINT ["docker-php-entrypoint"]
+
+CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/devcontainer/php/frankenphp/docker-php-entrypoint.sh
+++ b/devcontainer/php/frankenphp/docker-php-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# TODO: add deploy:setup command on first deployment
+
+# TODO: add deploy:finalize command to handle post deployment (artisan down, a migrate, a optimize, etc.)
+
+exec "$@"

--- a/devcontainer/ruby/docker-compose.yml
+++ b/devcontainer/ruby/docker-compose.yml
@@ -38,11 +38,3 @@ services:
     extends:
       file: ../base/docker-compose.yml
       service: mailpit
-
-volumes:
-  mysql:
-    name: ${APP_NAME}-vol-mysql
-    driver: local
-  redis:
-    name: ${APP_NAME}-vol-redis
-    driver: local

--- a/devcontainer/ruby/docker-compose.yml
+++ b/devcontainer/ruby/docker-compose.yml
@@ -1,10 +1,13 @@
 services:
-  devcontainer:
-    extends:
-      file: ../base/docker-compose.yml
-      service: devcontainer
-    build:
-      context: .
+  # devcontainer:
+  #   extends:
+  #     file: ../base/docker-compose.yml
+  #     service: devcontainer
+  #   build:
+  #     context: .
+  #   depends_on:
+  #     - mysql
+  #     - redis
     depends_on:
       - mysql
       - redis

--- a/devcontainer/ruby/docker-compose.yml
+++ b/devcontainer/ruby/docker-compose.yml
@@ -8,9 +8,14 @@ services:
   #   depends_on:
   #     - mysql
   #     - redis
+
+  ruby:
+    image: ruby:latest
     depends_on:
       - mysql
       - redis
+    volumes:
+      - ../:/app
 
   mysql:
     extends:

--- a/production/php/frankenphp/.dockerignore
+++ b/production/php/frankenphp/.dockerignore
@@ -1,0 +1,2 @@
+Caddyfile
+Dockerfile

--- a/production/php/frankenphp/Caddyfile
+++ b/production/php/frankenphp/Caddyfile
@@ -1,0 +1,43 @@
+{
+	acme_dns cloudflare {$CLOUDFLARE_DNS_API_TOKEN}
+
+	{$CADDY_GLOBAL_OPTIONS}
+
+	frankenphp {
+		#worker /path/to/your/worker.php
+		{$FRANKENPHP_CONFIG}
+	}
+
+	# https://caddyserver.com/docs/caddyfile/directives#sorting-algorithm
+	order php_server before file_server
+	order php before file_server
+}
+
+{$CADDY_EXTRA_CONFIG}
+
+{$SERVER_NAME:localhost} {
+	root * public/
+	encode zstd gzip
+
+	{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+	# Needed for Symfony, Laravel and other projects using the Symfony HttpFoundation component
+	request_header X-Sendfile-Type x-accel-redirect
+	request_header X-Accel-Mapping ../private-files=/private-files
+
+	intercept {
+		@accel header X-Accel-Redirect *
+		handle_response @accel {
+			root private-files/
+			rewrite * {resp.header.X-Accel-Redirect}
+			method * GET
+
+			# Remove the X-Accel-Redirect header set by PHP for increased security
+			header -X-Accel-Redirect
+
+			file_server
+		}
+	}
+
+	php_server
+}

--- a/production/php/frankenphp/Dockerfile
+++ b/production/php/frankenphp/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+ARG PACKAGE_VERSION="1.1.0"
+ARG BASE_IMAGE="dunglas/frankenphp:${PACKAGE_VERSION}"
+
+FROM "${BASE_IMAGE}-builder" AS builder
+
+COPY --from=caddy:builder /usr/bin/xcaddy /usr/bin/xcaddy
+
+# CGO must be enabled to build FrankenPHP
+ENV CGO_ENABLED=1 \
+    XCADDY_SETCAP=1 \
+    XCADDY_GO_BUILD_FLAGS="-ldflags='-w -s' -tags=nobadger,nomysql,nopgx" \
+    CGO_CFLAGS="$(php-config --includes)" \
+    CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs)"
+
+RUN set -eux; \
+  xcaddy build \
+  --output /usr/local/bin/frankenphp \
+  --with github.com/dunglas/frankenphp=./ \
+  --with github.com/dunglas/frankenphp/caddy=./caddy/ \
+  --with github.com/caddy-dns/cloudflare;
+
+FROM ${BASE_IMAGE} AS runner
+
+WORKDIR /app
+
+RUN set -eux; \
+  install-php-extensions \
+  @composer \
+  intl \
+  pdo_pgsql \
+  pdo_mysql \
+  zip \
+  && pecl install redis \
+  && docker-php-ext-enable redis \
+  && cp $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini;
+
+# Replace the official binary by the one containing our custom modules
+COPY --from=builder /usr/local/bin/frankenphp /usr/local/bin/frankenphp
+COPY --link deployment/Caddyfile /etc/caddy/Caddyfile
+COPY --link --chmod=755 deployment/docker-php-entrypoint.sh /usr/local/bin/docker-php-entrypoint
+
+COPY ../ ./
+
+RUN set -eux; \
+  composer install -n --no-cache --prefer-dist --no-dev --no-scripts -o -a
+
+ENTRYPOINT ["docker-php-entrypoint"]
+
+CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/production/php/frankenphp/docker-php-entrypoint.sh
+++ b/production/php/frankenphp/docker-php-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# TODO: add deploy:setup command on first deployment
+
+# TODO: add deploy:finalize command to handle post deployment (artisan down, a migrate, a optimize, etc.)
+
+exec "$@"


### PR DESCRIPTION
**Note**: should be merged after frankenphp branch

Similar to how `laravel/sail` publishes its files into a `docker/` subdirectory, docker-base should be pulled into the project as a submodule or subtree so it can be centrally managed yet modified on a per project basis. 